### PR TITLE
Evolution: Correct spelling of smart charge suspend

### DIFF
--- a/core/res/res/values/evolution_config.xml
+++ b/core/res/res/values/evolution_config.xml
@@ -331,7 +331,7 @@
     <integer name="config_smartChargingBatteryLevel">80</integer>
     <integer name="config_smartChargingBatteryResumeLevel">60</integer>
     <string name="config_SmartChargingSysfsNode" translatable="false">/sys/class/power_supply/battery/input_suspend</string>
-    <string name="config_SmartChargingSupspendValue" translatable="false">1</string>
+    <string name="config_SmartChargingSuspendValue" translatable="false">1</string>
     <string name="config_SmartChargingResumeValue" translatable="false">0</string>
 
     <!-- -1 means use same as config_screenBrightnessDoze -->

--- a/core/res/res/values/evolution_symbols.xml
+++ b/core/res/res/values/evolution_symbols.xml
@@ -239,7 +239,7 @@
     <java-symbol type="integer" name="config_smartChargingBatteryLevel" />
     <java-symbol type="integer" name="config_smartChargingBatteryResumeLevel" />
     <java-symbol type="string" name="config_SmartChargingSysfsNode" />
-    <java-symbol type="string" name="config_SmartChargingSupspendValue" />
+    <java-symbol type="string" name="config_SmartChargingSuspendValue" />
     <java-symbol type="string" name="config_SmartChargingResumeValue" />
 
     <java-symbol type="integer" name="config_screenBrightnessPulse" />

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -1135,7 +1135,7 @@ public final class PowerManagerService extends SystemService
         mPowerInputSupsendSysfsNode = resources.getString(
                 com.android.internal.R.string.config_SmartChargingSysfsNode);
         mPowerInputSupsendValue = resources.getString(
-                com.android.internal.R.string.config_SmartChargingSupspendValue);
+                com.android.internal.R.string.config_SmartChargingSuspendValue);
         mPowerInputResumeValue = resources.getString(
                 com.android.internal.R.string.config_SmartChargingResumeValue);
         mSmartChargingResetStats = Settings.System.getInt(mContext.getContentResolver(),


### PR DESCRIPTION
Change-Id: I1d559ede16eab18e2ffa0593f9dabe8d31b9637f
Signed-off-by: nysascape <jago@nysascape.digital>