### PR TITLE
fw/b: set button backlight brightness with BRIGHTNESS_MODE_BUTTON

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -937,7 +937,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
             mBrightnessReasonTemp.setReason(BrightnessReason.REASON_SCREEN_OFF);
             LogicalLight buttonsLight = mLights.getLight(LightsManager.LIGHT_ID_BUTTONS);
             if (buttonsLight != null) {
-                buttonsLight.setBrightness(brightnessState);
+                buttonsLight.setBrightness(brightnessState, LogicalLight.BRIGHTNESS_MODE_BUTTON);
             }
         }
 
@@ -945,7 +945,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
         if (state == Display.STATE_DOZE || state == Display.STATE_DOZE_SUSPEND) {
             LogicalLight buttonsLight = mLights.getLight(LightsManager.LIGHT_ID_BUTTONS);
             if (buttonsLight != null) {
-                buttonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT);
+                buttonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT, LogicalLight.BRIGHTNESS_MODE_BUTTON);
             }
         }
 

--- a/services/core/java/com/android/server/lights/LogicalLight.java
+++ b/services/core/java/com/android/server/lights/LogicalLight.java
@@ -50,6 +50,11 @@ public abstract class LogicalLight {
     public static final int BRIGHTNESS_MODE_SENSOR = Brightness.SENSOR;
 
     /**
+     * Light brightness for button backlight.
+     */
+    public static final int BRIGHTNESS_MODE_BUTTON = 3;
+
+    /**
      * Low-persistence light mode.
      */
     public static final int BRIGHTNESS_MODE_LOW_PERSISTENCE = Brightness.LOW_PERSISTENCE;

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -2512,12 +2512,12 @@ public final class PowerManagerService extends SystemService
                                         mLastButtonActivityTime : mLastUserActivityTime;
                                 if (mButtonTimeout != 0 &&
                                         now > mLastButtonActivityTime + mButtonTimeout) {
-                                    mButtonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT);
+                                    mButtonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT, LogicalLight.BRIGHTNESS_MODE_BUTTON);
                                     mButtonOn = false;
                                 } else {
                                     if ((!mButtonLightOnKeypressOnly || mButtonPressed) &&
                                             !mProximityPositive) {
-                                        mButtonsLight.setBrightness(buttonBrightness);
+                                        mButtonsLight.setBrightness(buttonBrightness, LogicalLight.BRIGHTNESS_MODE_BUTTON);
                                         mButtonPressed = false;
                                         if (buttonBrightness != PowerManager.BRIGHTNESS_OFF_FLOAT &&
                                                 mButtonTimeout != 0) {
@@ -2540,7 +2540,7 @@ public final class PowerManagerService extends SystemService
                             mUserActivitySummary = USER_ACTIVITY_SCREEN_DIM;
                             if (getWakefulnessLocked() == WAKEFULNESS_AWAKE) {
                                 if (mButtonsLight != null) {
-                                    mButtonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT);
+                                    mButtonsLight.setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT, LogicalLight.BRIGHTNESS_MODE_BUTTON);
                                     mButtonOn = false;
                                 }
                             }


### PR DESCRIPTION
LightImpl.setBrightness(float brightness) defaults to using
BRIGHTNESS_MODE_USER. Google implements two paths in this function,
and the default new path calls SurfaceControl.setDisplayBrightness()
no matter which LightImpl the function is called from. As a result,
setting button backlight brightness actually sets the screen panel
brightness on some devices with hwc brightness support.

Therefore, add a new mode of BRIGHTNESS_MODE_BUTTON and set
brightness with this mode, so that it falls back to the old path
using setLightLocked().

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>