### PR TITLE
fixup! DozeSensors: Only use proximity sensor if supported

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
@@ -81,7 +81,7 @@ public class DozeSensors {
     private long mDebounceFrom;
     private boolean mSettingRegistered;
     private boolean mListening;
-    private boolean mDisableProx;
+    private boolean mProximitySupported;
 
     @VisibleForTesting
     public enum DozeSensorsUiEvent implements UiEventLogger.UiEventEnum {
@@ -114,7 +114,7 @@ public class DozeSensors {
         mResolver = mContext.getContentResolver();
         mCallback = callback;
         mProximitySensor = proximitySensor;
-        mDisableProx = context.getResources().getBoolean(R.bool.doze_proximity_sensor_supported);
+        mProximitySupported  = context.getResources().getBoolean(R.bool.doze_proximity_sensor_supported);
 
         boolean alwaysOn = mConfig.alwaysOnEnabled(UserHandle.USER_CURRENT);
         mSensors = new TriggerSensor[] {
@@ -177,7 +177,7 @@ public class DozeSensors {
                         dozeLog),
         };
 
-        if (!mDisableProx) {
+        if (mProximitySupported) {
             setProxListening(false);  // Don't immediately start listening when we register.
             mProximitySensor.register(
                     proximityEvent -> {
@@ -317,7 +317,7 @@ public class DozeSensors {
         for (TriggerSensor s : mSensors) {
             pw.println("  Sensor: " + s.toString());
         }
-        if (!mDisableProx) // Useless
+        if (mProximitySupported) // Useless
             pw.println("  ProxSensor: " + mProximitySensor.toString());
     }
 
@@ -325,7 +325,7 @@ public class DozeSensors {
      * @return true if prox is currently near, false if far or null if unknown.
      */
     public Boolean isProximityCurrentlyNear() {
-        return mDisableProx ? null : mProximitySensor.isNear();
+        return !mProximitySupported ? null : mProximitySensor.isNear();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
* Previous logic inverted the boolean and broke proximity sensor turning off AOD when is covered

Signed-off-by: daniml3 <danimoral1001@gmail.com>
Change-Id: I458443decb1f211cfdb839384d83bebe7feb5507
Signed-off-by: chandu078 <chandudyavanapelli03@gmail.com>