### PR TITLE
DisplayPowerController: make brightness ramp rate overlay-able

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -524,11 +524,11 @@
     <!-- Flag indicating whether we should enable smart battery. -->
     <bool name="config_smart_battery_available">false</bool>
 
-    <!-- Fast brightness animation ramp rate in brightness units per second-->
-    <integer translatable="false" name="config_brightness_ramp_rate_fast">180</integer>
+    <!-- Slow brightness animation ramp rate in float. -->
+    <item name="config_brightnessRampRateSlowFloat" format="float" type="dimen">0.2352941</item>
 
-    <!-- Slow brightness animation ramp rate in brightness units per second-->
-    <integer translatable="false" name="config_brightness_ramp_rate_slow">60</integer>
+    <!-- Fast brightness animation ramp rate in float. -->
+    <item name="config_brightnessRampRateFastFloat" format="float" type="dimen">0.7058823</item>
 
     <!-- Don't name config resources like this.  It should look like config_annoyDianne -->
     <bool name="config_annoy_dianne">true</bool>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -1985,6 +1985,8 @@
   <java-symbol type="dimen" name="config_screenBrightnessSettingDefaultFloat" />
   <java-symbol type="dimen" name="config_screenBrightnessDozeFloat" />
   <java-symbol type="dimen" name="config_screenBrightnessDimFloat" />
+  <java-symbol type="dimen" name="config_brightnessRampRateSlowFloat" />
+  <java-symbol type="dimen" name="config_brightnessRampRateFastFloat" />
   <java-symbol type="integer" name="config_screenBrightnessDark" />
   <java-symbol type="integer" name="config_screenBrightnessDim" />
   <java-symbol type="integer" name="config_screenBrightnessDoze" />
@@ -1992,8 +1994,6 @@
   <java-symbol type="integer" name="config_shutdownBatteryTemperature" />
   <java-symbol type="integer" name="config_undockedHdmiRotation" />
   <java-symbol type="integer" name="config_virtualKeyQuietTimeMillis" />
-  <java-symbol type="integer" name="config_brightness_ramp_rate_fast" />
-  <java-symbol type="integer" name="config_brightness_ramp_rate_slow" />
   <java-symbol type="integer" name="config_screen_rotation_color_transition" />
   <java-symbol type="layout" name="am_compat_mode_dialog" />
   <java-symbol type="layout" name="launch_warning" />

--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -334,8 +334,8 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
     private BrightnessReason mBrightnessReasonTemp = new BrightnessReason();
 
     // Brightness animation ramp rates in brightness units per second
-    private final float mBrightnessRampRateSlow = 0.2352941f;
-    private final float mBrightnessRampRateFast = 0.7058823f;
+    private final float mBrightnessRampRateSlow;
+    private final float mBrightnessRampRateFast;
 
 
     // Whether or not to skip the initial brightness ramps into STATE_ON.
@@ -472,6 +472,11 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
 
         mSkipScreenOnBrightnessRamp = resources.getBoolean(
                 com.android.internal.R.bool.config_skipScreenOnBrightnessRamp);
+
+        mBrightnessRampRateSlow = resources.getFloat(
+                com.android.internal.R.dimen.config_brightnessRampRateSlowFloat);
+        mBrightnessRampRateFast = resources.getFloat(
+                com.android.internal.R.dimen.config_brightnessRampRateFastFloat);
 
         if (mUseSoftwareAutoBrightnessConfig) {
             final float dozeScaleFactor = resources.getFraction(
@@ -1899,6 +1904,8 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
         pw.println("  mScreenBrightnessForVrRangeMaximum=" + mScreenBrightnessForVrRangeMaximum);
         pw.println("  mScreenBrightnessForVrDefault=" + mScreenBrightnessForVrDefault);
         pw.println("  mUseSoftwareAutoBrightnessConfig=" + mUseSoftwareAutoBrightnessConfig);
+        pw.println("  mBrightnessRampRateFast=" + mBrightnessRampRateFast);
+        pw.println("  mBrightnessRampRateSlow=" + mBrightnessRampRateSlow);
         pw.println("  mAllowAutoBrightnessWhileDozingConfig=" +
                 mAllowAutoBrightnessWhileDozingConfig);
         pw.println("  mSkipScreenOnBrightnessRamp=" + mSkipScreenOnBrightnessRamp);


### PR DESCRIPTION
Google switched to float based values on android11 after commit
"Add support for brightness as a float" [1]. In this commit,
variable "mBrightnessRampRateFast" and "mBrightnessRampRateSlow"
are changed to fixed float values instead of the old integer
values that were read from config.

mBrightnessRampRateSlow = 0.2352941f (equivalent of 60/255)
mBrightnessRampRateFast = 0.7058823f (equivalent of 180/255)

These values may not work well on all devices, and some devices
may wish to change it to a slower rate to provide smoother auto
brightness transitions. It was doable in the old integer format
but impossible now because of the fixed float. Therefore, make
the float values of fast/slow ramp rate overlay-able.

While we are at it, drop the integer configs. Not sure why Google
did not remove them as they are currently not used anywhere.

ref:
https://android.googlesource.com/platform/frameworks/base/+/d4eb2951966fbd621c7570d59f30b93d61d8347a

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>