### PR TITLE
base: Make vendor mismatch message optional

### DIFF
--- a/core/res/res/values/evolution_config.xml
+++ b/core/res/res/values/evolution_config.xml
@@ -365,4 +365,7 @@
     <bool name="config_proximityCheckOnWake">false</bool>
     <integer name="config_proximityCheckTimeout">250</integer>
     <bool name="config_proximityCheckOnWakeEnabledByDefault">false</bool>
+
+    <!-- Whether or not we should show vendor mismatch message -->
+    <bool name="config_show_vendor_mismatch_message">true</bool>
 </resources>

--- a/core/res/res/values/evolution_strings.xml
+++ b/core/res/res/values/evolution_strings.xml
@@ -96,5 +96,5 @@
     <string name="fontservice_incompatible_font">The font package you\'ve installed is not compatible due to missing fonts.xml on their files. Please contact the package developer for support.</string>
 
     <!-- Vendor mismatch fingerprint warning [CHAR LIMIT=NONE] -->
-    <string name="system_error_vendorprint">It appears your vendor image may be out of date. Please flash the latest vendor image for your device.</string>
+    <string name="system_error_vendorprint">Your vendor image does not match the system. Please flash the <xliff:g id="string">%s</xliff:g> vendor image for your device</string>
 </resources>

--- a/core/res/res/values/evolution_strings.xml
+++ b/core/res/res/values/evolution_strings.xml
@@ -94,4 +94,7 @@
 
     <!-- [CHAR LIMIT=NONE] Error when a package is installed but got the missing fonts.xml file, notifying the user why it isn't showing up. -->
     <string name="fontservice_incompatible_font">The font package you\'ve installed is not compatible due to missing fonts.xml on their files. Please contact the package developer for support.</string>
+
+    <!-- Vendor mismatch fingerprint warning [CHAR LIMIT=NONE] -->
+    <string name="system_error_vendorprint">It appears your vendor image may be out of date. Please flash the latest vendor image for your device.</string>
 </resources>

--- a/core/res/res/values/evolution_symbols.xml
+++ b/core/res/res/values/evolution_symbols.xml
@@ -276,4 +276,7 @@
 
   <!-- Proximity check on screen on default -->
   <java-symbol type="bool" name="config_proximityCheckOnWakeEnabledByDefault" />
+
+  <!-- Vendor mismatch fingerprint warning -->
+  <java-symbol type="string" name="system_error_vendorprint" />
 </resources>

--- a/core/res/res/values/evolution_symbols.xml
+++ b/core/res/res/values/evolution_symbols.xml
@@ -279,4 +279,7 @@
 
   <!-- Vendor mismatch fingerprint warning -->
   <java-symbol type="string" name="system_error_vendorprint" />
+
+  <!-- Whether or not we should show vendor mismatch message -->
+  <java-symbol type="bool" name="config_show_vendor_mismatch_message" />
 </resources>

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6533,7 +6533,9 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                 if (!Build.isBuildConsistent()) {
                     Slog.e(TAG, "Build fingerprint is not consistent, warning user");
                     mUiHandler.post(() -> {
-                        if (mShowDialogs) {
+                        boolean mShowVendorMismatch = Resources.getSystem().getBoolean(
+                                R.bool.config_show_vendor_mismatch_message);
+                        if (mShowDialogs && mShowVendorMismatch) {
                             String buildfingerprint = SystemProperties.get("ro.build.fingerprint");
                             String[] splitfingerprint = buildfingerprint.split("/");
                             String vendorid = splitfingerprint[3];

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6538,7 +6538,7 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                             d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                             d.setCancelable(false);
                             d.setTitle(mUiContext.getText(R.string.android_system_label));
-                            d.setMessage(mUiContext.getText(R.string.system_error_manufacturer));
+                            d.setMessage(mUiContext.getText(R.string.system_error_vendorprint));
                             d.setButton(DialogInterface.BUTTON_POSITIVE,
                                     mUiContext.getText(R.string.ok),
                                     mUiHandler.obtainMessage(DISMISS_DIALOG_UI_MSG, d));

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6534,11 +6534,14 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                     Slog.e(TAG, "Build fingerprint is not consistent, warning user");
                     mUiHandler.post(() -> {
                         if (mShowDialogs) {
+                            String buildfingerprint = SystemProperties.get("ro.build.fingerprint");
+                            String[] splitfingerprint = buildfingerprint.split("/");
+                            String vendorid = splitfingerprint[3];
                             AlertDialog d = new BaseErrorDialog(mUiContext);
                             d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                             d.setCancelable(false);
                             d.setTitle(mUiContext.getText(R.string.android_system_label));
-                            d.setMessage(mUiContext.getText(R.string.system_error_vendorprint));
+                            d.setMessage(mUiContext.getString(R.string.system_error_vendorprint, vendorid));
                             d.setButton(DialogInterface.BUTTON_POSITIVE,
                                     mUiContext.getText(R.string.ok),
                                     mUiHandler.obtainMessage(DISMISS_DIALOG_UI_MSG, d));


### PR DESCRIPTION
I was getting this warning after every boot with my OSS Vendor despite of everything was working fine. I got rid of this pointless message making it configurable with these commits.
![photo_2021-06-21_16-03-18](https://user-images.githubusercontent.com/4729640/122775594-95892b00-d2aa-11eb-95ff-80ad47d05c3d.jpg)
