### PR TITLE
AndroidSClockController: fix IndexOutOfBoundsException

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/clock/AndroidSClockController.java
+++ b/packages/SystemUI/src/com/android/keyguard/clock/AndroidSClockController.java
@@ -320,7 +320,7 @@ public class AndroidSClockController implements ClockPlugin {
                 button.setTextColor(blendedColor);
                 button.setGravity(Gravity.START);
                 button.setTag(itemTag);
-                final int viewIndex = i - (mHasHeader ? 0 : 0);
+                final int viewIndex = i - (mHasHeader ? 1 : 0);
                 mRow.addView(button, viewIndex);
             } else {
                 button.setTextSize(isDateSlice ? mTitleTextSize : mSliceTextSize);


### PR DESCRIPTION
This has to be a typo, right?

E AndroidRuntime: java.lang.IndexOutOfBoundsException: index=1 count=0
E AndroidRuntime: 	at android.view.ViewGroup.addInArray(ViewGroup.java:5363)
E AndroidRuntime: 	at android.view.ViewGroup.addViewInner(ViewGroup.java:5256)
E AndroidRuntime: 	at android.view.ViewGroup.addView(ViewGroup.java:5064)
E AndroidRuntime: 	at android.view.ViewGroup.addView(ViewGroup.java:5004)
E AndroidRuntime: 	at com.android.keyguard.clock.AndroidSClockController.setSlice(AndroidSClockController.java:324)
...

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>