### PR TITLE
base: enable doze by default

### DIFF
--- a/core/res/res/values/evolution_config.xml
+++ b/core/res/res/values/evolution_config.xml
@@ -370,5 +370,5 @@
     <bool name="config_proximityCheckOnWakeEnabledByDefault">false</bool>
 
     <!-- Whether doze feature is enabled by default in settings -->
-    <bool name="config_dozeDefaultEnabled">false</bool>
+    <bool name="config_dozeDefaultEnabled">true</bool>
 </resources>


### PR DESCRIPTION
Let's stick to AOSP's default behavior.

ref:
https://android.googlesource.com/platform/frameworks/base/+/android-11.0.0_r39/core/java/android/hardware/display/AmbientDisplayConfiguration.java#60

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>