### PR TITLE
IDE clock: fix the C++ syntax and format

### DIFF
--- a/packages/SystemUI/res-keyguard/layout/p404_ide_clock.xml
+++ b/packages/SystemUI/res-keyguard/layout/p404_ide_clock.xml
@@ -40,7 +40,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="\u003Ciostream\u003E"
+                    android:text="\u003Cstring\u003E"
                     android:textColor="#3DDB86"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -84,7 +84,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="int main  "
+                    android:text="int main"
                     android:textSize="14sp"
                     android:textStyle="bold" />
 
@@ -92,7 +92,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="( )"
+                    android:text="()"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -164,7 +164,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -205,7 +205,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -243,7 +243,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -283,7 +283,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />

--- a/packages/SystemUI/res-keyguard/layout/p404_ide_clock_preview.xml
+++ b/packages/SystemUI/res-keyguard/layout/p404_ide_clock_preview.xml
@@ -31,7 +31,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="\u003Ciostream\u003E"
+                    android:text="\u003Cstring\u003E"
                     android:textColor="#3DDB86"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -75,7 +75,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="int main  "
+                    android:text="int main"
                     android:textSize="14sp"
                     android:textStyle="bold" />
 
@@ -83,7 +83,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
-                    android:text="( )"
+                    android:text="()"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -155,7 +155,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -196,7 +196,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -234,7 +234,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />
@@ -274,7 +274,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@*android:string/config_headlineFontFamilyMedium"
                     android:paddingStart="-0.5dip"
-                    android:text="\u0022  ;"
+                    android:text="\u0022;"
                     android:textColor="?attr/wallpaperTextColor"
                     android:textSize="14sp"
                     android:textStyle="bold" />

--- a/packages/SystemUI/src/com/android/keyguard/clock/AndroidSClockController.java
+++ b/packages/SystemUI/src/com/android/keyguard/clock/AndroidSClockController.java
@@ -146,6 +146,7 @@ public class AndroidSClockController implements ClockPlugin {
     private final HashMap<View, PendingIntent> mClickActions;
     private Uri mKeyguardSliceUri;
 
+    private final ClockPalette mPalette = new ClockPalette();
     private int mTextColor;
     private float mDarkAmount = 0;
     private int mRowHeight = 0;
@@ -256,7 +257,7 @@ public class AndroidSClockController implements ClockPlugin {
 
     @Override
     public void setTextColor(int color) {
-        mClock.setTextColor(color);
+        updateTextColors();
     }
 
     @Override
@@ -488,6 +489,11 @@ public class AndroidSClockController implements ClockPlugin {
                 ((TextView) v).setTextColor(blendedColor);
             }
         }
+
+        ColorExtractor.GradientColors colors = mColorExtractor.getColors(
+                WallpaperManager.FLAG_LOCK);
+        mPalette.setColorPalette(colors.supportsDarkText(), colors.getColorPalette());
+        mClock.setTextColor(ColorUtils.blendARGB(mPalette.getPrimaryColor(), Color.WHITE, 0.3f));
     }
 
     int getTextColor() {


### PR DESCRIPTION
- iostream is unnecessary when the "code" does not contain a single
  cin or cout;
- Since std::string is used, make sure to include <string>;
- Remove the weird spaces.

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>