### PR TITLE
fixup! keyguard: Introduce Android 12 ShapeShift clock

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardSliceProvider.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardSliceProvider.java
@@ -225,7 +225,7 @@ public class KeyguardSliceProvider extends SliceProvider implements
         String currentClock = Settings.Secure.getString(
                 mContentResolver, Settings.Secure.LOCK_SCREEN_CUSTOM_CLOCK_FACE);
         boolean isTypeClockSelected = currentClock == null ? false : currentClock.contains("Type");
-        boolean isTwelveClockSelected = currentClock == null ? false : currentClock.contains("Android") && currentClock.contains("S") && currentClock.contains("Twelve");
+        boolean isTwelveClockSelected = currentClock == null ? false : (currentClock.contains("Android") && currentClock.contains("S")) || currentClock.contains("Twelve");
         boolean isCenterMusicTickerEnabled = Settings.System.getIntForUser(getContext().getContentResolver(),
                 Settings.System.AMBIENT_MUSIC_TICKER, 1, UserHandle.USER_CURRENT) == 2;
         // Show header if music is playing and the status bar is in the shade state. This way, an


### PR DESCRIPTION
We do not have a clock called AndroidSTwelve. This fixes the
missing media header.

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>