### PR TITLE
BrightnessSynchronizer: make brightness tolerance overlay-able

### DIFF
--- a/core/java/com/android/internal/BrightnessSynchronizer.java
+++ b/core/java/com/android/internal/BrightnessSynchronizer.java
@@ -19,6 +19,7 @@ package com.android.internal;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.res.Resources;
 import android.database.ContentObserver;
 import android.net.Uri;
 import android.os.Handler;
@@ -49,7 +50,7 @@ public class BrightnessSynchronizer {
 
     // The tolerance within which we consider brightness values approximately equal to eachother.
     // This value is approximately 1/3 of the smallest possible brightness value.
-    public static final float EPSILON = 0.001f;
+    public static float EPSILON = 0.001f;
 
     private final Context mContext;
 
@@ -76,6 +77,9 @@ public class BrightnessSynchronizer {
     public BrightnessSynchronizer(Context context) {
         final BrightnessSyncObserver mBrightnessSyncObserver;
         mContext = context;
+        final Resources resources = context.getResources();
+        EPSILON = resources.getFloat(
+                com.android.internal.R.dimen.config_brightnessChangeTolerance);
         mBrightnessSyncObserver = new BrightnessSyncObserver(mHandler);
         mBrightnessSyncObserver.startObserving();
 

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -535,6 +535,10 @@
 
     <!-- XXXXXX END OF RESOURCES USING WRONG NAMING CONVENTION -->
 
+    <!-- The tolerance within which the brightness values are considered equal to each other.
+         The value should be less than the smallest possible brightness value -->
+    <item name="config_brightnessChangeTolerance" format="float" type="dimen">0.001</item>
+
     <!-- If this is true, notification effects will be played by the notification server.
          When false, car notification effects will be handled elsewhere. -->
     <bool name="config_enableServerNotificationEffectsForAutomotive">false</bool>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -1985,6 +1985,7 @@
   <java-symbol type="dimen" name="config_screenBrightnessDimFloat" />
   <java-symbol type="dimen" name="config_brightnessRampRateSlowFloat" />
   <java-symbol type="dimen" name="config_brightnessRampRateFastFloat" />
+  <java-symbol type="dimen" name="config_brightnessChangeTolerance" />
   <java-symbol type="integer" name="config_screenBrightnessDark" />
   <java-symbol type="integer" name="config_screenBrightnessDim" />
   <java-symbol type="integer" name="config_screenBrightnessDoze" />


### PR DESCRIPTION
The value of EPSILON is used to determine if two brightness values
are equal or not. The LocalDisplayDevice in LocalDisplayAdapter
only updates the brightness when the delta is bigger than EPSILON.

Google hard-coded EPSILON to 0.001f because OLED panels on Pixel
devices have 0-255 as the backlight range. EPSILON=0.001f guarantees
that the brightness is only updated when the change is at least
1/255.

For devices with a bigger range of backlight brightness, 0.001f
causes discontinuous brightness update. For example, for a panel
of [0, 4095] brightness range,

slider raw value | valFloat | LocalDisplayAdapter | panel
9601		0.007154266
9677		0.007267978
9830		0.007499619
9906		0.0076160324
9982		0.007733343
10058		0.007851549
10135		0.0079722265	0.0079722265	33
10211		0.0080922395
10287		0.0082131475
10363		0.008334952
10439		0.008457654
10516		0.005828848
10592		0.008707392
10668		0.008832796
10744		0.008959095
10821		0.009087971	0.009087971	37
10897		0.009216075
...

The brightness adjustment basically jumps every 4-5 steps. It is
not a problem in the higher range, but the transition becomes
obviously unsmooth in the lower brightness range due to how the
gamma-to-linear conversion works.

Therefore, make the tolerance overlay-able so that devices can set
a proper value accordingly.

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>
Change-Id: I0821130e756b93d256cb5a385963f6180cd529e2