### PR TITLE
Center clock fixes

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
@@ -32,6 +32,7 @@ import android.util.Pair;
 import android.view.DisplayCutout;
 import android.view.Gravity;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -417,6 +418,15 @@ public class PhoneStatusBarView extends PanelBar {
                 getPaddingTop(),
                 size.x - contentRect.right,
                 getPaddingBottom());
+
+        // Apply negative paddings to centered area layout so that we'll actually be on the center.
+        final int winRotation = getDisplay().getRotation();
+        LayoutParams centeredAreaParams =
+                (LayoutParams) findViewById(R.id.center_clock_layout).getLayoutParams();
+        centeredAreaParams.leftMargin =
+                winRotation == Surface.ROTATION_0 ? -contentRect.left : 0;
+        centeredAreaParams.rightMargin =
+                winRotation == Surface.ROTATION_0 ? -(size.x - contentRect.right) : 0;
     }
 
     public void setHeadsUpVisible(boolean headsUpVisible) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
@@ -64,6 +64,13 @@ public class PhoneStatusBarView extends PanelBar {
 
     private ViewGroup mStatusBarContents;
 
+    private int mBasePaddingBottomcc;
+    private int mBasePaddingLeftcc;
+    private int mBasePaddingRightcc;
+    private int mBasePaddingTopcc;
+
+    private ViewGroup mStatusBarContentscc;
+
     StatusBar mBar;
 
     boolean mIsFullyOpenedPanel = false;
@@ -122,11 +129,22 @@ public class PhoneStatusBarView extends PanelBar {
             return;
         }
 
+        if (mStatusBarContentscc == null) {
+            return;
+        }
+
         mStatusBarContents.setPaddingRelative(
             mBasePaddingLeft + horizontalShift,
             mBasePaddingTop + verticalShift,
             mBasePaddingRight + horizontalShift,
             mBasePaddingBottom - verticalShift
+        );
+
+        mStatusBarContentscc.setPaddingRelative(
+            mBasePaddingLeftcc + horizontalShift,
+            mBasePaddingTopcc + verticalShift,
+            mBasePaddingRightcc + horizontalShift,
+            mBasePaddingBottomcc - verticalShift
         );
         invalidate();
     }
@@ -140,11 +158,16 @@ public class PhoneStatusBarView extends PanelBar {
         mCutoutSpace = findViewById(R.id.cutout_space_view);
         mCenterIconSpace = findViewById(R.id.centered_icon_area);
         mStatusBarContents = (ViewGroup) findViewById(R.id.status_bar_contents);
+        mStatusBarContentscc = (ViewGroup) findViewById(R.id.center_clock_layout);
 
         mBasePaddingLeft = mStatusBarContents.getPaddingStart();
         mBasePaddingTop = mStatusBarContents.getPaddingTop();
         mBasePaddingRight = mStatusBarContents.getPaddingEnd();
         mBasePaddingBottom = mStatusBarContents.getPaddingBottom();
+        mBasePaddingLeftcc = mStatusBarContentscc.getPaddingStart();
+        mBasePaddingTopcc = mStatusBarContentscc.getPaddingTop();
+        mBasePaddingRightcc = mStatusBarContentscc.getPaddingEnd();
+        mBasePaddingBottomcc = mStatusBarContentscc.getPaddingBottom();
 
         updateResources();
     }


### PR DESCRIPTION
Hello! I am working on the 8T and I've noticed a couple of issues regarding the center clock (CC). 
The first is that the CC is not centered on devices with side notch out of the box. Yes, there is a solution to this in the source already that enables maintainers add paddings for CC but I think that fix is a hit or miss. This way it seems to be done precisely.

The second is that the CC shifts differently than the rest of SB items. I have fixed this. I am sure there are better approaches than mine, however, it works well and doesn't seem to affect anything else.