### PR TITLE
Clock hiding improvements

### DIFF
--- a/packages/SystemUI/res/layout/quick_qs_status_icons.xml
+++ b/packages/SystemUI/res/layout/quick_qs_status_icons.xml
@@ -35,8 +35,8 @@
         android:gravity="center_vertical|start"
         >
 
-        <com.android.systemui.statusbar.policy.Clock
-            android:id="@+id/clock"
+        <com.android.systemui.statusbar.policy.ClockEQS
+            android:id="@+id/clock_eqs"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:minHeight="48dp"

--- a/packages/SystemUI/src/com/android/systemui/qs/QuickStatusBarHeader.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QuickStatusBarHeader.java
@@ -55,6 +55,7 @@ import com.android.systemui.statusbar.phone.StatusBarIconController.TintedIconMa
 import com.android.systemui.statusbar.phone.StatusBarWindowView;
 import com.android.systemui.statusbar.phone.StatusIconContainer;
 import com.android.systemui.statusbar.policy.Clock;
+import com.android.systemui.statusbar.policy.ClockEQS;
 import com.android.systemui.statusbar.policy.VariableDateView;
 import com.android.systemui.statusbar.policy.NetworkTraffic;
 
@@ -158,7 +159,7 @@ public class QuickStatusBarHeader extends FrameLayout implements
         mNetworkTraffic = findViewById(R.id.networkTraffic);
 
         mClockContainer = findViewById(R.id.clock_container);
-        mClockView = findViewById(R.id.clock);
+        mClockView = findViewById(R.id.clock_eqs);
         mClockView.setQsHeader();
         mClockView.setOnClickListener(this);
         mClockView.setOnLongClickListener(this);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/Clock.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/Clock.java
@@ -91,7 +91,7 @@ public class Clock extends TextView implements
     protected SimpleDateFormat mClockFormat;
     private SimpleDateFormat mContentDescriptionFormat;
     protected Locale mLocale;
-    private Handler autoHideHandler = new Handler();
+    protected Handler autoHideHandler = new Handler();
 
     private static final int HIDE_DURATION = 60; // 1 minute
     private static final int SHOW_DURATION = 5; // 5 seconds
@@ -128,9 +128,9 @@ public class Clock extends TextView implements
     private Handler mSecondsHandler;
     private SettingsObserver mSettingsObserver;
 
-    private boolean mClockAutoHide;
-    private int mHideDuration = HIDE_DURATION;
-    private int mShowDuration = SHOW_DURATION;
+    protected boolean mClockAutoHide;
+    protected int mHideDuration = HIDE_DURATION;
+    protected int mShowDuration = SHOW_DURATION;
     private Handler mHandler = new Handler();
 
     /**

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockCenter.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockCenter.java
@@ -51,11 +51,24 @@ public class ClockCenter extends Clock {
         updateClockVisibility();
     }
 
+    private void autoHideClock() {
+        setVisibility(View.GONE);
+        autoHideHandler.postDelayed(()->updateClockVisibility(), mHideDuration * 1000);
+    }
+
     protected void updateClockVisibility() {
         boolean visible = mClockStyle == STYLE_CLOCK_CENTER && mShowClock
                 && mClockVisibleByPolicy && mClockVisibleByUser;
         int visibility = visible ? View.VISIBLE : View.GONE;
+        try {
+            autoHideHandler.removeCallbacksAndMessages(null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
         setVisibility(visibility);
+        if (mClockAutoHide && visible) {
+            autoHideHandler.postDelayed(()->autoHideClock(), mShowDuration * 1000);
+        }
     }
 
     public void disable(int state1, int state2, boolean animate) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockEQS.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockEQS.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy;
+
+import android.app.StatusBarManager;
+import android.content.Context;
+import android.os.Handler;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.android.systemui.Dependency;
+
+public class ClockEQS extends Clock {
+
+    private boolean mClockVisibleByPolicy = true;
+    private boolean mClockVisibleByUser = true;
+
+    public ClockEQS(Context context) {
+        this(context, null);
+    }
+
+    public ClockEQS(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ClockEQS(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public void setClockVisibleByUser(boolean visible) {
+        mClockVisibleByUser = visible;
+        updateClockVisibility();
+    }
+
+    public void setClockVisibilityByPolicy(boolean visible) {
+        mClockVisibleByPolicy = visible;
+        updateClockVisibility();
+    }
+
+    protected void updateClockVisibility() {
+        boolean visible = mShowClock
+                && mClockVisibleByPolicy && mClockVisibleByUser;
+        int visibility = visible ? View.VISIBLE : View.GONE;
+        setVisibility(visibility);
+    }
+
+    public void disable(int state1, int state2, boolean animate) {
+        boolean clockVisibleByPolicy = (state1 & StatusBarManager.DISABLE_CLOCK) == 0;
+        if (clockVisibleByPolicy != mClockVisibleByPolicy) {
+            setClockVisibilityByPolicy(clockVisibleByPolicy);
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockRight.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/ClockRight.java
@@ -51,11 +51,24 @@ public class ClockRight extends Clock {
         updateClockVisibility();
     }
 
+    private void autoHideClock() {
+        setVisibility(View.GONE);
+        autoHideHandler.postDelayed(()->updateClockVisibility(), mHideDuration * 1000);
+    }
+
     protected void updateClockVisibility() {
         boolean visible = mClockStyle == STYLE_CLOCK_RIGHT && mShowClock
                 && mClockVisibleByPolicy && mClockVisibleByUser;
         int visibility = visible ? View.VISIBLE : View.GONE;
+        try {
+            autoHideHandler.removeCallbacksAndMessages(null);
+        } catch (NullPointerException e) {
+            // Do nothing
+        }
         setVisibility(visibility);
+        if (mClockAutoHide && visible) {
+            autoHideHandler.postDelayed(()->autoHideClock(), mShowDuration * 1000);
+        }
     }
 
     public void disable(int state1, int state2, boolean animate) {


### PR DESCRIPTION
Fix the hiding for center and right clock
Don't hide expanded QS clock so the user can tell time without locking their phone or going to the homescreen