### PR TITLE
PixelPropsUtils: Use OnePlus 8 Pro for Fortnite

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -124,7 +124,8 @@ public class PixelPropsUtils {
             "com.riotgames.league.wildrift",
             "com.riotgames.league.wildrifttw",
             "com.riotgames.league.wildriftvn",
-            "com.netease.lztgglobal"
+            "com.netease.lztgglobal",
+            "com.epicgames.fortnite"
     };
 
     private static final String[] packagesToChangeMI11 = {


### PR DESCRIPTION
Fortnite 90fps is supported on OnePlus 8Pro, so I added it