### PR TITLE
SystemUI: Logo: Avoid NPE

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/evolution/logo/LogoImage.java
+++ b/packages/SystemUI/src/com/android/systemui/evolution/logo/LogoImage.java
@@ -193,6 +193,8 @@ public abstract class LogoImage extends ImageView {
             case 19:
                 drawable = mContext.getResources().getDrawable(R.drawable.ic_xbox);
                 break;
+            default:
+                drawable = mContext.getResources().getDrawable(R.drawable.ic_evolution_logo);
         }
 
         setImageDrawable(null);


### PR DESCRIPTION
set fallback to ic_evolution_logo to prevent NullPointerException in case of mLogoStyle doesn't belong to any of below, which causes crash and bootloop on  `drawable.setTint(mTintColor);`

logcat:
```
10-24 22:35:59.887  3948  3948 E AndroidRuntime: FATAL EXCEPTION: main
10-24 22:35:59.887  3948  3948 E AndroidRuntime: Process: com.android.systemui, PID: 3948
10-24 22:35:59.887  3948  3948 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.graphics.drawable.Drawable.setTint(int)' on a null object reference
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at com.android.systemui.evolution.logo.LogoImage.updateLogo(LogoImage.java:202)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at com.android.systemui.evolution.logo.LogoImage.updateSettings(LogoImage.java:218)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at com.android.systemui.evolution.logo.LogoImage.onAttachedToWindow(LogoImage.java:111)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.View.dispatchAttachedToWindow(View.java:21291)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3498)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2771)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2286)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8951)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1231)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.Choreographer.doCallbacks(Choreographer.java:899)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.Choreographer.doFrame(Choreographer.java:832)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:942)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:201)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:288)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7893)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:550)
10-24 22:35:59.887  3948  3948 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```