### PR TITLE
PixelPropsUtils: Spoof Samsung Accessory apps

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -44,6 +44,7 @@ public class PixelPropsUtils {
     private static final String PACKAGE_PS = "com.android.vending";
     private static final String PACKAGE_SI = "com.google.android.settings.intelligence";
     private static final String SAMSUNG = "com.samsung.android.";
+    private static final String SAMSUNGACCESSORY = "com.samsung.accessory.";
     private static final String SPOOF_MUSIC_APPS = "persist.sys.disguise_props_for_music_app";
 
     private static final String TAG = PixelPropsUtils.class.getSimpleName();
@@ -255,6 +256,7 @@ public class PixelPropsUtils {
         }
         if (packageName.startsWith("com.google.")
                 || packageName.startsWith(SAMSUNG)
+                || packageName.startsWith(SAMSUNGACCESSORY)
                 || Arrays.asList(extraPackagesToChange).contains(packageName)) {
 
             Map<String, Object> propsToChange = new HashMap<>();


### PR DESCRIPTION
Some Samsung wearable plugins such as Galaxy Buds2 Pro Manager use a different package name to other Samsung apps and hence do not function without spoofing first.

Spoof com.samsung.accessory.*  in addition to com.samsung.android*