### PR TITLE
frameworks/base: Make "external/robolectric" visible to "frameworks/base:framework-all"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -152,6 +152,7 @@ java_library {
     sdk_version: "core_platform",
     visibility: [
         // DO NOT ADD ANY MORE ENTRIES TO THIS LIST
+        "//external/robolectric:__subpackages__",
         "//external/robolectric-shadows:__subpackages__",
         "//frameworks/layoutlib:__subpackages__",
     ],


### PR DESCRIPTION
**error**: external/robolectric/Android.bp:70:1: module "**robolectric_android-all-device-deps_upstream**" variant "**linux_glibc_common**": depends on **//frameworks/base:framework-all** which is not visible to this mo dule