### PR TITLE
PixelPropsUtils: Add Gameprops for Battlegrounds Mobile India (BGMI)

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -61,6 +61,7 @@ public class PixelPropsUtils {
     private static final Map<String, Object> propsToChangeOP9R;
     private static final Map<String, Object> propsToChange11T;
     private static final Map<String, Object> propsToChangeF4;
+    private static final Map<String, Object> propsToChangeK30U;
     private static final Map<String, Object> propsToChangeMeizu;
     private static final Map<String, ArrayList<String>> propsToKeep;
 
@@ -126,6 +127,11 @@ public class PixelPropsUtils {
             "com.pearlabyss.blackdesertm.gl"
     };
 
+    // Packages to Spoof as Redmi K30 Ultra
+    private static final String[] packagesToChangeK30U = {
+            "com.pubg.imobile"
+    };
+
     // Packages to Spoof as Xperia 5
     private static final String[] packagesToChangeXP5 = {
             "com.garena.game.codm",
@@ -136,7 +142,6 @@ public class PixelPropsUtils {
     // Packages to Spoof as OnePlus 8 Pro
     private static final String[] packagesToChangeOP8P = {
             "com.netease.lztgglobal",
-            "com.pubg.imobile",
             "com.pubg.krmobile",
             "com.rekoo.pubgm",
             "com.riotgames.league.wildrift",
@@ -257,6 +262,9 @@ public class PixelPropsUtils {
         propsToChangeMeizu.put("DISPLAY", "Flyme");
         propsToChangeMeizu.put("PRODUCT", "meizu_16thPlus_CN");
         propsToChangeMeizu.put("MODEL", "meizu 16th Plus");
+        propsToChangeK30U = new HashMap<>();
+        propsToChangeK30U.put("MODEL", "M2006J10C");
+        propsToChangeK30U.put("MANUFACTURER", "Xiaomi");
     }
 
     public static void setProps(Context context) {
@@ -347,6 +355,13 @@ public class PixelPropsUtils {
             } else if (Arrays.asList(packagesToChangeOP9R).contains(packageName)) {
                 dlog("Defining props for: " + packageName);
                 for (Map.Entry<String, Object> prop : propsToChangeOP9R.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
+                }
+            } else if (Arrays.asList(packagesToChangeK30U).contains(packageName)) {
+                if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
+                for (Map.Entry<String, Object> prop : propsToChangeK30U.entrySet()) {
                     String key = prop.getKey();
                     Object value = prop.getValue();
                     setPropValue(key, value);


### PR DESCRIPTION
* Krafton disabled 90fps for android, so OP8P spoofing is no longer working
* Now spoofing bgmi with Redmi K30 Ultra, unlocks Smooth-Extreme to HDR-Extreme