### PR TITLE
Add Gameprops for Battlegrounds Mobile India (BGMI)

### DIFF
--- a/core/java/com/android/internal/util/evolution/GamesPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/GamesPropsUtils.java
@@ -44,6 +44,11 @@ public class GamesPropsUtils {
             "com.vng.mlbbvn"
     };
 
+    private static final Map<String, Object> propsToChangeK30U = createMap("M2006J10C", "Xiaomi");
+    private static final String[] packagesToChangeK30U = { // spoof as Redmi K30 Ultra
+            "com.pubg.imobile"
+    };
+
     private static final Map<String, Object> propsToChangeMI13P = createMap("2210132C", "Xiaomi");
     private static final String[] packagesToChangeMI13P = { // spoof as Mi 13 PRO
             "com.levelinfinite.sgameGlobal",
@@ -53,7 +58,6 @@ public class GamesPropsUtils {
     private static final Map<String, Object> propsToChangeOP8P = createMap("IN2020", "OnePlus");
     private static final String[] packagesToChangeOP8P = { // spoof as OnePlus 8 PRO
             "com.netease.lztgglobal",
-            "com.pubg.imobile",
             "com.pubg.krmobile",
             "com.rekoo.pubgm",
             "com.riotgames.league.wildrift",
@@ -116,6 +120,8 @@ public class GamesPropsUtils {
                 propsToChange = propsToChangeBS4;
             } else if (Arrays.asList(packagesToChangeMI11TP).contains(packageName)) {
                 propsToChange = propsToChangeMI11TP;
+            } else if (Arrays.asList(packagesToChangeK30U).contains(packageName)) {
+                propsToChange = propsToChangeK30U;
             } else if (Arrays.asList(packagesToChangeMI13P).contains(packageName)) {
                 propsToChange = propsToChangeMI13P;
             } else if (Arrays.asList(packagesToChangeOP8P).contains(packageName)) {


### PR DESCRIPTION
* OP8P spoofing is no longer working and is just a dummy patch now.
* Henceby spoofing bgmi with Redmi K30 Ultra, which unlocks Smooth-Extreme to HDR-Extreme

*** Adjusted for the refactored workaround after https://github.com/Evolution-X/frameworks_base/commit/73d61b45ac1b72efc02337c17a6d8b646c0eddfa.