### PR TITLE
base: core: Unregister broadcast receiver only when registered

### DIFF
--- a/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
+++ b/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
@@ -42,6 +42,7 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
     private Runnable mOnChangeRunnable;
     private Handler mMainHandler;
     private IntentFilter mIntentFilter;
+    private boolean mRegistered = false;
 
     public GestureNavigationSettingsObserver(Handler handler, Context context,
             Runnable onChangeRunnable) {
@@ -141,6 +142,7 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
      */
     public void register() {
         mContext.registerReceiver(mBroadcastReceiver, mIntentFilter);
+        mRegistered = true;
         ContentResolver r = mContext.getContentResolver();
         r.registerContentObserver(
                 Settings.Secure.getUriFor(Settings.Secure.BACK_GESTURE_INSET_SCALE_LEFT),
@@ -205,7 +207,9 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
     }
 
     public void unregister() {
-        mContext.unregisterReceiver(mBroadcastReceiver);
+        if (mRegistered) {
+            mContext.unregisterReceiver(mBroadcastReceiver);
+        }
         mContext.getContentResolver().unregisterContentObserver(this);
         DeviceConfig.removeOnPropertiesChangedListener(mOnPropertiesChangedListener);
     }


### PR DESCRIPTION
- Prevent launcher crashing every time when gesture setting is enabled and launcher is refreshed

09-11 09:43:43.668 13392 13392 D AndroidRuntime: Shutting down VM
09-11 09:43:43.669 13392 13392 E AndroidRuntime: FATAL EXCEPTION: main
09-11 09:43:43.669 13392 13392 E AndroidRuntime: Process: com.android.launcher3, PID: 13392
09-11 09:43:43.669 13392 13392 E AndroidRuntime: java.lang.RuntimeException: Unable to stop service com.android.quickstep.TouchInteractionService@72163a9: java.lang.IllegalArgumentException: Receiver not registered: com.android.internal.policy.GestureNavigationSettingsObserver$2@2944dd0
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ActivityThread.handleStopService(ActivityThread.java:4707)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ActivityThread.-$$Nest$mhandleStopService(Unknown Source:0)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2186)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:201)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:288)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7966)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:942)
09-11 09:43:43.669 13392 13392 E AndroidRuntime: Caused by: java.lang.IllegalArgumentException: Receiver not registered: com.android.internal.policy.GestureNavigationSettingsObserver$2@2944dd0
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1662)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1843)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:812)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:812)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.internal.policy.GestureNavigationSettingsObserver.unregister(GestureNavigationSettingsObserver.java:208)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.launcher3.taskbar.TaskbarInsetsController.onDestroy(TaskbarInsetsController.kt:76)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.launcher3.taskbar.TaskbarControllers.onDestroy(TaskbarControllers.java:224)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.launcher3.taskbar.TaskbarActivityContext.onDestroy(TaskbarActivityContext.java:563)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.launcher3.taskbar.TaskbarManager.destroyExistingTaskbar(TaskbarManager.java:280)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.launcher3.taskbar.TaskbarManager.destroy(TaskbarManager.java:510)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at com.android.quickstep.TouchInteractionService.onDestroy(TouchInteractionService.java:598)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        at android.app.ActivityThread.handleStopService(ActivityThread.java:4687)
09-11 09:43:43.669 13392 13392 E AndroidRuntime:        ... 9 more