### PR TITLE
I've picked few little-fun commits. Please conside to merge below

### DIFF
--- a/core/java/android/os/Build.java
+++ b/core/java/android/os/Build.java
@@ -1305,7 +1305,7 @@ public class Build {
      */
     public static boolean isBuildConsistent() {
         // Don't care on eng builds.  Incremental build may trigger false negative.
-        if (IS_ENG) return true;
+        /*if (IS_ENG) return true;
 
         if (IS_TREBLE_ENABLED) {
             // If we can run this code, the device should already pass AVB.
@@ -1318,6 +1318,7 @@ public class Build {
             }
 
             return result == 0;
+            return true;
         }
 
         final String system = SystemProperties.get("ro.system.build.fingerprint");
@@ -1340,7 +1341,7 @@ public class Build {
                         + " but vendor reported " + vendor);
                 return false;
             }
-        }
+        } */
 
         /* TODO: Figure out issue with checks failing
         if (!TextUtils.isEmpty(bootimage)) {

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5768,6 +5768,26 @@ public final class Settings {
         };
 
         /**
+         * Display style of the status bar battery information
+         * 0: Display the battery an icon in portrait mode
+         * 1: Display the battery as a circle
+         * 2: Display the battery as plain text
+         * default: 0
+         * @hide
+         */
+        public static final String STATUS_BAR_BATTERY_STYLE = "status_bar_battery_style";
+
+        /**
+         * Status bar battery %
+         * 0: Hide the battery percentage
+         * 1: Display the battery percentage inside the icon
+         * 2: Display the battery percentage next to the icon
+         * @hide
+         */
+        public static final String STATUS_BAR_SHOW_BATTERY_PERCENT =
+                "status_bar_show_battery_percent";
+
+       /**
          * These are all public system settings
          *
          * @hide
@@ -5885,6 +5905,8 @@ public final class Settings {
             PRIVATE_SETTINGS.add(CAMERA_FLASH_NOTIFICATION);
             PRIVATE_SETTINGS.add(SCREEN_FLASH_NOTIFICATION);
             PRIVATE_SETTINGS.add(SCREEN_FLASH_NOTIFICATION_COLOR);
+            PRIVATE_SETTINGS.add(STATUS_BAR_BATTERY_STYLE);
+            PRIVATE_SETTINGS.add(STATUS_BAR_SHOW_BATTERY_PERCENT);
         }
 
         /**

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -10877,7 +10877,7 @@ public final class Settings {
 
         /**
          * What behavior should be invoked when the volume hush gesture is triggered
-         * One of VOLUME_HUSH_OFF, VOLUME_HUSH_VIBRATE, VOLUME_HUSH_MUTE.
+         * One of VOLUME_HUSH_OFF, VOLUME_HUSH_VIBRATE, VOLUME_HUSH_MUTE, VOLUME_HUSH_CYCLE.
          *
          * @hide
          */
@@ -10894,6 +10894,9 @@ public final class Settings {
         /** @hide */
         @SystemApi
         public static final int VOLUME_HUSH_MUTE = 2;
+        /** @hide */
+        @SystemApi
+        public static final int VOLUME_HUSH_CYCLE = 3;
 
         /**
          * The number of times (integer) the user has manually enabled battery saver.

--- a/core/res/res/values/evolution_strings.xml
+++ b/core/res/res/values/evolution_strings.xml
@@ -8,4 +8,7 @@
     <string name="aerr_copy">Copy crash log URL</string>
     <string name="url_copy_success">URL copied successfully</string>
     <string name="url_copy_failed">An error occured while uploading the log to Pasty</string>
+
+    <!-- Cycle through ringer modes -->
+    <string name="volume_dialog_ringer_guidance_normal">Calls and notifications will ring</string>
 </resources>

--- a/core/res/res/values/evolution_symbols.xml
+++ b/core/res/res/values/evolution_symbols.xml
@@ -36,4 +36,7 @@
     <java-symbol type="array" name="config_cameraAuxPackageAllowList" />
     <java-symbol type="array" name="config_cameraAuxPackageExcludeList" />
     <java-symbol type="array" name="config_cameraHFRPrivAppList" />
+
+    <!-- Cycle through ringer modes -->
+    <java-symbol type="string" name="volume_dialog_ringer_guidance_normal" />
 </resources>

--- a/packages/SettingsLib/src/com/android/settingslib/graph/CircleBatteryDrawable.kt
+++ b/packages/SettingsLib/src/com/android/settingslib/graph/CircleBatteryDrawable.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ * Copyright (C) 2019 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settingslib.graph
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.*
+import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import com.android.settingslib.R
+import com.android.settingslib.Utils
+import kotlin.math.max
+import kotlin.math.min
+
+class CircleBatteryDrawable(private val context: Context, frameColor: Int) : Drawable() {
+    private val criticalLevel: Int
+    private val warningString: String
+    private val framePaint: Paint
+    private val batteryPaint: Paint
+    private val warningTextPaint: Paint
+    private val textPaint: Paint
+    private val boltPaint: Paint
+    private val plusPaint: Paint
+    private val powerSavePaint: Paint
+    private val colors: IntArray
+    private val boltPoints: FloatArray
+    private val boltPath = Path()
+    private val padding = Rect()
+    private val frame = RectF()
+    private val boltFrame = RectF()
+
+    private var chargeColor: Int
+    private var iconTint = Color.WHITE
+    private var intrinsicWidth: Int
+    private var intrinsicHeight: Int
+    private var height = 0
+    private var width = 0
+
+    // Dual tone implies that battery level is a clipped overlay over top of the whole shape
+    private var dualTone = false
+
+    override fun getIntrinsicHeight() = intrinsicHeight
+
+    override fun getIntrinsicWidth() = intrinsicWidth
+
+    var charging = false
+        set(value) {
+            field = value
+            postInvalidate()
+        }
+
+    var powerSaveEnabled = false
+        set(value) {
+            field = value
+            postInvalidate()
+        }
+
+    var showPercent = false
+        set(value) {
+            field = value
+            postInvalidate()
+        }
+
+    var batteryLevel = -1
+        set(value) {
+            field = value
+            postInvalidate()
+        }
+
+    // an approximation of View.postInvalidate()
+    private fun postInvalidate() {
+        unscheduleSelf { invalidateSelf() }
+        scheduleSelf({ invalidateSelf() }, 0)
+    }
+
+    override fun setBounds(left: Int, top: Int, right: Int, bottom: Int) {
+        super.setBounds(left, top, right, bottom)
+        updateSize()
+    }
+
+    private fun updateSize() {
+        val res = context.resources
+        height = bounds.bottom - padding.bottom - (bounds.top + padding.top)
+        width = bounds.right - padding.right - (bounds.left + padding.left)
+        warningTextPaint.textSize = height * 0.75f
+        intrinsicHeight = res.getDimensionPixelSize(R.dimen.battery_height)
+        intrinsicWidth = res.getDimensionPixelSize(R.dimen.battery_height)
+    }
+
+    override fun getPadding(padding: Rect): Boolean {
+        if (this.padding.left == 0 &&
+            this.padding.top == 0 &&
+            this.padding.right == 0 &&
+            this.padding.bottom == 0
+        ) {
+            return super.getPadding(padding)
+        }
+        padding.set(this.padding)
+        return true
+    }
+
+    private fun getColorForLevel(percent: Int): Int {
+        var thresh: Int
+        var color = 0
+        var i = 0
+        while (i < colors.size) {
+            thresh = colors[i]
+            color = colors[i + 1]
+            if (percent <= thresh) {
+                // Respect tinting for "normal" level
+                return if (i == colors.size - 2) {
+                    iconTint
+                } else {
+                    color
+                }
+            }
+            i += 2
+        }
+        return color
+    }
+
+    private fun batteryColorForLevel(level: Int) =
+        if (charging || powerSaveEnabled)
+            chargeColor
+        else
+            getColorForLevel(level)
+
+    fun setColors(fgColor: Int, bgColor: Int, singleToneColor: Int) {
+        val fillColor = if (dualTone) fgColor else singleToneColor
+
+        iconTint = fillColor
+        framePaint.color = bgColor
+        boltPaint.color = fillColor
+        chargeColor = fillColor
+
+        invalidateSelf()
+    }
+
+    override fun draw(c: Canvas) {
+        if (batteryLevel == -1) return
+        val circleSize = min(width, height)
+        val strokeWidth = circleSize / 6.5f
+        framePaint.strokeWidth = strokeWidth
+        framePaint.style = Paint.Style.STROKE
+        batteryPaint.strokeWidth = strokeWidth
+        batteryPaint.style = Paint.Style.STROKE
+        powerSavePaint.strokeWidth = strokeWidth
+        frame[
+                strokeWidth / 2.0f + padding.left, strokeWidth / 2.0f,
+                circleSize - strokeWidth / 2.0f + padding.left
+        ] = circleSize - strokeWidth / 2.0f
+        // set the battery charging color
+        batteryPaint.color = batteryColorForLevel(batteryLevel)
+        if (charging) { // define the bolt shape
+            val bl = frame.left + frame.width() / 3.0f
+            val bt = frame.top + frame.height() / 3.4f
+            val br = frame.right - frame.width() / 4.0f
+            val bb = frame.bottom - frame.height() / 5.6f
+            if (boltFrame.left != bl ||
+                boltFrame.top != bt ||
+                boltFrame.right != br ||
+                boltFrame.bottom != bb
+            ) {
+                boltFrame[bl, bt, br] = bb
+                boltPath.reset()
+                boltPath.moveTo(
+                    boltFrame.left + boltPoints[0] * boltFrame.width(),
+                    boltFrame.top + boltPoints[1] * boltFrame.height()
+                )
+                var i = 2
+                while (i < boltPoints.size) {
+                    boltPath.lineTo(
+                        boltFrame.left + boltPoints[i] * boltFrame.width(),
+                        boltFrame.top + boltPoints[i + 1] * boltFrame.height()
+                    )
+                    i += 2
+                }
+                boltPath.lineTo(
+                    boltFrame.left + boltPoints[0] * boltFrame.width(),
+                    boltFrame.top + boltPoints[1] * boltFrame.height()
+                )
+            }
+            c.drawPath(boltPath, boltPaint)
+        }
+        // draw thin gray ring first
+        c.drawArc(frame, 270f, 360f, false, framePaint)
+        // draw colored arc representing charge level
+        if (batteryLevel > 0) {
+            if (!charging && powerSaveEnabled) {
+                c.drawArc(frame, 270f, 3.6f * batteryLevel, false, powerSavePaint)
+            } else {
+                c.drawArc(frame, 270f, 3.6f * batteryLevel, false, batteryPaint)
+            }
+        }
+        // compute percentage text
+        if (!charging && batteryLevel != 100 && showPercent) {
+            textPaint.color = getColorForLevel(batteryLevel)
+            textPaint.textSize = height * 0.52f
+            val textHeight = -textPaint.fontMetrics.ascent
+            val pctText =
+                if (batteryLevel > criticalLevel)
+                    batteryLevel.toString()
+                else
+                    warningString
+            val pctX = width * 0.5f
+            val pctY = (height + textHeight) * 0.47f
+            c.drawText(pctText, pctX, pctY, textPaint)
+        }
+    }
+
+    // Some stuff required by Drawable.
+    override fun setAlpha(alpha: Int) {}
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        framePaint.colorFilter = colorFilter
+        batteryPaint.colorFilter = colorFilter
+        warningTextPaint.colorFilter = colorFilter
+        boltPaint.colorFilter = colorFilter
+        plusPaint.colorFilter = colorFilter
+    }
+
+    override fun getOpacity() = PixelFormat.UNKNOWN
+
+    companion object {
+        private fun loadPoints(
+            res: Resources,
+            pointArrayRes: Int
+        ): FloatArray {
+            val pts = res.getIntArray(pointArrayRes)
+            var maxX = 0
+            var maxY = 0
+            run {
+                var i = 0
+                while (i < pts.size) {
+                    maxX = max(maxX, pts[i])
+                    maxY = max(maxY, pts[i + 1])
+                    i += 2
+                }
+            }
+            val ptsF = FloatArray(pts.size)
+            var i = 0
+            while (i < pts.size) {
+                ptsF[i] = pts[i].toFloat() / maxX
+                ptsF[i + 1] = pts[i + 1].toFloat() / maxY
+                i += 2
+            }
+            return ptsF
+        }
+    }
+
+    init {
+        val res = context.resources
+        val color_levels = res.obtainTypedArray(R.array.batterymeter_color_levels)
+        val color_values = res.obtainTypedArray(R.array.batterymeter_color_values)
+        colors = IntArray(2 * color_levels.length())
+        for (i in 0 until color_levels.length()) {
+            colors[2 * i] = color_levels.getInt(i, 0)
+            if (color_values.getType(i) == TypedValue.TYPE_ATTRIBUTE) {
+                colors[2 * i + 1] = Utils.getColorAttrDefaultColor(
+                    context,
+                    color_values.getThemeAttributeId(i, 0)
+                )
+            } else {
+                colors[2 * i + 1] = color_values.getColor(i, 0)
+            }
+        }
+        color_levels.recycle()
+        color_values.recycle()
+        warningString = res.getString(R.string.battery_meter_very_low_overlay_symbol)
+        criticalLevel = res.getInteger(
+            com.android.internal.R.integer.config_criticalBatteryWarningLevel
+        )
+        framePaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        framePaint.color = frameColor
+        framePaint.isDither = true
+        batteryPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        batteryPaint.isDither = true
+        textPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        textPaint.typeface = Typeface.create("sans-serif-condensed", Typeface.BOLD)
+        textPaint.textAlign = Paint.Align.CENTER
+        warningTextPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        warningTextPaint.typeface = Typeface.create("sans-serif", Typeface.BOLD)
+        warningTextPaint.textAlign = Paint.Align.CENTER
+        if (colors.size > 1) {
+            warningTextPaint.color = colors[1]
+        }
+        chargeColor = Utils.getColorStateListDefaultColor(context, R.color.meter_consumed_color)
+        boltPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        boltPaint.color = Utils.getColorStateListDefaultColor(
+            context,
+            R.color.batterymeter_bolt_color
+        )
+        boltPoints =
+            loadPoints(res, R.array.batterymeter_bolt_points)
+        plusPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        plusPaint.color = Utils.getColorStateListDefaultColor(
+            context,
+            R.color.batterymeter_plus_color
+        )
+        powerSavePaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        powerSavePaint.color = plusPaint.color
+        powerSavePaint.style = Paint.Style.STROKE
+        intrinsicWidth = res.getDimensionPixelSize(R.dimen.battery_width)
+        intrinsicHeight = res.getDimensionPixelSize(R.dimen.battery_height)
+
+        dualTone = res.getBoolean(com.android.internal.R.bool.config_batterymeterDualTone)
+    }
+}

--- a/packages/SettingsLib/src/com/android/settingslib/graph/ThemedBatteryDrawable.kt
+++ b/packages/SettingsLib/src/com/android/settingslib/graph/ThemedBatteryDrawable.kt
@@ -25,6 +25,7 @@ import android.graphics.Path
 import android.graphics.PixelFormat
 import android.graphics.Rect
 import android.graphics.RectF
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.PathParser
 import android.util.TypedValue
@@ -106,6 +107,12 @@ open class ThemedBatteryDrawable(private val context: Context, frameColor: Int) 
             postInvalidate()
         }
 
+    var showPercent = false
+        set(value) {
+            field = value
+            postInvalidate()
+        }
+
     private val fillColorStrokePaint = Paint(Paint.ANTI_ALIAS_FLAG).also { p ->
         p.color = frameColor
         p.alpha = 255
@@ -150,6 +157,11 @@ open class ThemedBatteryDrawable(private val context: Context, frameColor: Int) 
         p.isDither = true
         p.strokeWidth = 0f
         p.style = Paint.Style.FILL_AND_STROKE
+    }
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).also { p ->
+        p.typeface = Typeface.create("sans-serif-condensed", Typeface.BOLD)
+        p.textAlign = Paint.Align.CENTER
     }
 
     init {
@@ -251,6 +263,25 @@ open class ThemedBatteryDrawable(private val context: Context, frameColor: Int) 
             c.drawPath(scaledPlus, fillPaint)
         }
         c.restore()
+
+        if (!charging && batteryLevel < 100 && showPercent) {
+            textPaint.textSize = bounds.height() * 0.38f
+            val textHeight = -textPaint.fontMetrics.ascent
+            val pctX = bounds.width() * 0.5f
+            val pctY = (bounds.height() + textHeight) * 0.5f
+
+            textPaint.color = fillColor
+            c.drawText(batteryLevel.toString(), pctX, pctY, textPaint)
+
+            textPaint.color = fillColor.toInt().inv() or 0xFF000000.toInt()
+            c.save()
+            c.clipRect(fillRect.left,
+                    fillRect.top + (fillRect.height() * (1 - fillFraction)),
+                    fillRect.right,
+                    fillRect.bottom)
+            c.drawText(batteryLevel.toString(), pctX, pctY, textPaint)
+            c.restore()
+        }
     }
 
     private fun batteryColorForLevel(level: Int): Int {

--- a/packages/SettingsProvider/src/android/provider/settings/validators/SystemSettingsValidators.java
+++ b/packages/SettingsProvider/src/android/provider/settings/validators/SystemSettingsValidators.java
@@ -227,5 +227,7 @@ public class SystemSettingsValidators {
         VALIDATORS.put(System.CAMERA_FLASH_NOTIFICATION, BOOLEAN_VALIDATOR);
         VALIDATORS.put(System.SCREEN_FLASH_NOTIFICATION, BOOLEAN_VALIDATOR);
         VALIDATORS.put(System.SCREEN_FLASH_NOTIFICATION_COLOR, ANY_INTEGER_VALIDATOR);
+        VALIDATORS.put(System.STATUS_BAR_BATTERY_STYLE, new InclusiveIntegerRangeValidator(0, 2));
+        VALIDATORS.put(System.STATUS_BAR_SHOW_BATTERY_PERCENT, new InclusiveIntegerRangeValidator(0, 2));
     }
 }

--- a/packages/SystemUI/res/layout/battery_percentage_view.xml
+++ b/packages/SystemUI/res/layout/battery_percentage_view.xml
@@ -25,6 +25,5 @@
         android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         android:textColor="?android:attr/textColorPrimary"
         android:gravity="center_vertical|start"
-        android:paddingStart="@dimen/battery_level_padding_start"
         android:importantForAccessibility="no"
         />

--- a/packages/SystemUI/res/values/evolution_dimens.xml
+++ b/packages/SystemUI/res/values/evolution_dimens.xml
@@ -4,5 +4,6 @@
      SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
-
+    <!-- Width of the battery icon in the status bar when set to circle style. -->
+    <dimen name="status_bar_battery_icon_circle_width">14.5dp</dimen>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/battery/AccessorizedBatteryDrawable.kt
+++ b/packages/SystemUI/src/com/android/systemui/battery/AccessorizedBatteryDrawable.kt
@@ -195,6 +195,11 @@ class AccessorizedBatteryDrawable(
         mainBatteryDrawable.setColors(fgColor, bgColor, singleToneColor)
     }
 
+    /** Shows the battery percentage. */
+    fun showPercent(percentage: Boolean) {
+        mainBatteryDrawable.showPercent = percentage
+    }
+
     /** Notifies this drawable that the density might have changed. */
     fun notifyDensityChanged() {
         density = context.resources.displayMetrics.density

--- a/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterView.java
+++ b/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterView.java
@@ -38,6 +38,7 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -46,6 +47,7 @@ import androidx.annotation.StyleRes;
 import androidx.annotation.VisibleForTesting;
 
 import com.android.app.animation.Interpolators;
+import com.android.settingslib.graph.CircleBatteryDrawable;
 import com.android.systemui.DualToneHandler;
 import com.android.systemui.R;
 import com.android.systemui.plugins.DarkIconDispatcher;
@@ -59,6 +61,10 @@ import java.util.ArrayList;
 
 public class BatteryMeterView extends LinearLayout implements DarkReceiver {
 
+    protected static final int BATTERY_STYLE_PORTRAIT = 0;
+    protected static final int BATTERY_STYLE_CIRCLE = 1;
+    protected static final int BATTERY_STYLE_TEXT = 2;
+
     @Retention(SOURCE)
     @IntDef({MODE_DEFAULT, MODE_ON, MODE_OFF, MODE_ESTIMATE})
     public @interface BatteryPercentMode {}
@@ -67,7 +73,8 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     public static final int MODE_OFF = 2;
     public static final int MODE_ESTIMATE = 3;
 
-    private final AccessorizedBatteryDrawable mDrawable;
+    private final AccessorizedBatteryDrawable mAccessorizedDrawable;
+    private final CircleBatteryDrawable mCircleDrawable;
     private final ImageView mBatteryIconView;
     private TextView mBatteryPercentView;
 
@@ -75,7 +82,6 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     private int mTextColor;
     private int mLevel;
     private int mShowPercentMode = MODE_DEFAULT;
-    private boolean mShowPercentAvailable;
     private String mEstimateText = null;
     private boolean mCharging;
     private boolean mIsBatteryDefender;
@@ -108,18 +114,18 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
         final int frameColor = atts.getColor(R.styleable.BatteryMeterView_frameColor,
                 context.getColor(R.color.meter_background_color));
         mPercentageStyleId = atts.getResourceId(R.styleable.BatteryMeterView_textAppearance, 0);
-        mDrawable = new AccessorizedBatteryDrawable(context, frameColor);
+        mAccessorizedDrawable = new AccessorizedBatteryDrawable(context, frameColor);
+        mCircleDrawable = new CircleBatteryDrawable(context, frameColor);
         atts.recycle();
-
-        mShowPercentAvailable = context.getResources().getBoolean(
-                com.android.internal.R.bool.config_battery_percentage_setting_available);
 
         setupLayoutTransition();
 
         mBatteryIconView = new ImageView(context);
-        mBatteryIconView.setImageDrawable(mDrawable);
+        updateDrawable();
         final MarginLayoutParams mlp = new MarginLayoutParams(
-                getResources().getDimensionPixelSize(R.dimen.status_bar_battery_icon_width),
+                getBatteryStyle() == BATTERY_STYLE_PORTRAIT ? getResources().getDimensionPixelSize(
+                R.dimen.status_bar_battery_icon_width) : getResources().getDimensionPixelSize(
+                R.dimen.status_bar_battery_icon_circle_width),
                 getResources().getDimensionPixelSize(R.dimen.status_bar_battery_icon_height));
         mlp.setMargins(0, 0, 0,
                 getResources().getDimensionPixelOffset(R.dimen.battery_margin_bottom));
@@ -155,6 +161,12 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
         setLayoutTransition(transition);
     }
 
+    protected void updateBatteryStyle() {
+        updateDrawable();
+        scaleBatteryMeterViews();
+        updatePercentView();
+    }
+
     public void setForceShowPercent(boolean show) {
         setPercentShowMode(show ? MODE_ON : MODE_DEFAULT);
     }
@@ -178,8 +190,8 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     @Override
     protected void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        updatePercentView();
-        mDrawable.notifyDensityChanged();
+        updateBatteryStyle();
+        mAccessorizedDrawable.notifyDensityChanged();
     }
 
     public void setColorsFromContext(Context context) {
@@ -202,15 +214,21 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
      * @param pluggedIn whether the device is plugged in or not
      */
     public void onBatteryLevelChanged(@IntRange(from = 0, to = 100) int level, boolean pluggedIn) {
-        mDrawable.setCharging(pluggedIn);
-        mDrawable.setBatteryLevel(level);
+        mAccessorizedDrawable.setCharging(pluggedIn);
+        mCircleDrawable.setCharging(pluggedIn);
+        mAccessorizedDrawable.setBatteryLevel(level);
+        mCircleDrawable.setBatteryLevel(level);
         mCharging = pluggedIn;
         mLevel = level;
         updatePercentText();
+        if (pluggedIn) {
+            updateShowPercent();
+        }
     }
 
     void onPowerSaveChanged(boolean isPowerSave) {
-        mDrawable.setPowerSaveEnabled(isPowerSave);
+        mAccessorizedDrawable.setPowerSaveEnabled(isPowerSave);
+        mCircleDrawable.setPowerSaveEnabled(isPowerSave);
     }
 
     void onIsBatteryDefenderChanged(boolean isBatteryDefender) {
@@ -329,16 +347,21 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     void updateShowPercent() {
         final boolean showing = mBatteryPercentView != null;
         // TODO(b/140051051)
-        final boolean systemSetting = 0 != whitelistIpcs(() -> Settings.System
-                .getIntForUser(getContext().getContentResolver(),
-                SHOW_BATTERY_PERCENT, 0, UserHandle.USER_CURRENT));
+        final int showBatteryPercent = Settings.System.getIntForUser(
+                getContext().getContentResolver(), Settings.System.STATUS_BAR_SHOW_BATTERY_PERCENT, 0,
+                UserHandle.USER_CURRENT);
+        final boolean drawPercentInside = mShowPercentMode == MODE_DEFAULT &&
+                showBatteryPercent == 1;
+        final boolean drawPercentOnly = mShowPercentMode == MODE_ESTIMATE ||
+                showBatteryPercent == 2;
         boolean shouldShow =
-                (mShowPercentAvailable && systemSetting && mShowPercentMode != MODE_OFF)
-                || mShowPercentMode == MODE_ON
-                || mShowPercentMode == MODE_ESTIMATE;
+                (drawPercentOnly && (!drawPercentInside || mCharging) ||
+                getBatteryStyle() == BATTERY_STYLE_TEXT);
         shouldShow = shouldShow && !mBatteryStateUnknown;
 
         if (shouldShow) {
+            mAccessorizedDrawable.showPercent(false);
+            mCircleDrawable.setShowPercent(false);
             if (!showing) {
                 mBatteryPercentView = loadPercentView();
                 if (mPercentageStyleId != 0) { // Only set if specified as attribute
@@ -350,7 +373,16 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
                         LayoutParams.WRAP_CONTENT,
                         LayoutParams.MATCH_PARENT));
             }
+            if (getBatteryStyle() == BATTERY_STYLE_TEXT) {
+                mBatteryPercentView.setPaddingRelative(0, 0, 0, 0);
+            } else {
+                Resources res = getContext().getResources();
+                mBatteryPercentView.setPaddingRelative(
+                        res.getDimensionPixelSize(R.dimen.battery_level_padding_start), 0, 0, 0);
+            }
         } else {
+            mAccessorizedDrawable.showPercent(drawPercentInside);
+            mCircleDrawable.setShowPercent(drawPercentInside);
             if (showing) {
                 removeView(mBatteryPercentView);
                 mBatteryPercentView = null;
@@ -378,7 +410,7 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
         if (mBatteryStateUnknown) {
             mBatteryIconView.setImageDrawable(getUnknownStateDrawable());
         } else {
-            mBatteryIconView.setImageDrawable(mDrawable);
+            updateDrawable();
         }
 
         updateShowPercent();
@@ -394,10 +426,12 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
         res.getValue(R.dimen.status_bar_icon_scale_factor, typedValue, true);
         float iconScaleFactor = typedValue.getFloat();
 
-        float mainBatteryHeight =
-                res.getDimensionPixelSize(R.dimen.status_bar_battery_icon_height) * iconScaleFactor;
-        float mainBatteryWidth =
-                res.getDimensionPixelSize(R.dimen.status_bar_battery_icon_width) * iconScaleFactor;
+        int batteryHeight = res.getDimensionPixelSize(R.dimen.status_bar_battery_icon_height);
+        int batteryWidth = getBatteryStyle() == BATTERY_STYLE_CIRCLE ?
+                res.getDimensionPixelSize(R.dimen.status_bar_battery_icon_circle_width) :
+                res.getDimensionPixelSize(R.dimen.status_bar_battery_icon_width);
+        float mainBatteryHeight = batteryHeight * iconScaleFactor;
+        float mainBatteryWidth = batteryWidth * iconScaleFactor;
 
         boolean displayShield = mDisplayShieldEnabled && mIsBatteryDefender;
         float fullBatteryIconHeight =
@@ -426,9 +460,32 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
                 Math.round(fullBatteryIconHeight));
         scaledLayoutParams.setMargins(0, marginTop, 0, marginBottom);
 
-        mDrawable.setDisplayShield(displayShield);
+        mAccessorizedDrawable.setDisplayShield(displayShield);
         mBatteryIconView.setLayoutParams(scaledLayoutParams);
-        mBatteryIconView.invalidateDrawable(mDrawable);
+        mBatteryIconView.invalidateDrawable(mAccessorizedDrawable);
+    }
+
+    private void updateDrawable() {
+        switch (getBatteryStyle()) {
+            case BATTERY_STYLE_PORTRAIT:
+                mBatteryIconView.setImageDrawable(mAccessorizedDrawable);
+                mBatteryIconView.setVisibility(View.VISIBLE);
+                break;
+            case BATTERY_STYLE_CIRCLE:
+                mBatteryIconView.setImageDrawable(mCircleDrawable);
+                mBatteryIconView.setVisibility(View.VISIBLE);
+                break;
+            case BATTERY_STYLE_TEXT:
+                mBatteryIconView.setVisibility(View.GONE);
+                mBatteryIconView.setImageDrawable(null);
+                break;
+        }
+    }
+
+    private int getBatteryStyle() {
+        return Settings.System.getIntForUser(getContext().getContentResolver(),
+                Settings.System.STATUS_BAR_BATTERY_STYLE, BATTERY_STYLE_PORTRAIT,
+                UserHandle.USER_CURRENT);
     }
 
     @Override
@@ -451,7 +508,8 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
      * @param singleToneColor
      */
     public void updateColors(int foregroundColor, int backgroundColor, int singleToneColor) {
-        mDrawable.setColors(foregroundColor, backgroundColor, singleToneColor);
+        mAccessorizedDrawable.setColors(foregroundColor, backgroundColor, singleToneColor);
+        mCircleDrawable.setColors(foregroundColor, backgroundColor, singleToneColor);
         mTextColor = singleToneColor;
         if (mBatteryPercentView != null) {
             mBatteryPercentView.setTextColor(singleToneColor);
@@ -463,10 +521,11 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     }
 
     public void dump(PrintWriter pw, String[] args) {
-        String powerSave = mDrawable == null ? null : mDrawable.getPowerSaveEnabled() + "";
+        String powerSave = mAccessorizedDrawable == null ?
+                null : mAccessorizedDrawable.getPowerSaveEnabled() + "";
         CharSequence percent = mBatteryPercentView == null ? null : mBatteryPercentView.getText();
         pw.println("  BatteryMeterView:");
-        pw.println("    mDrawable.getPowerSave: " + powerSave);
+        pw.println("    getPowerSave: " + powerSave);
         pw.println("    mBatteryPercentView.getText(): " + percent);
         pw.println("    mTextColor: #" + Integer.toHexString(mTextColor));
         pw.println("    mBatteryStateUnknown: " + mBatteryStateUnknown);

--- a/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterViewController.java
@@ -15,8 +15,6 @@
  */
 package com.android.systemui.battery;
 
-import static android.provider.Settings.System.SHOW_BATTERY_PERCENT;
-
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.ContentObserver;
@@ -68,7 +66,11 @@ public class BatteryMeterViewController extends ViewController<BatteryMeterView>
             if (StatusBarIconController.ICON_HIDE_LIST.equals(key)) {
                 ArraySet<String> icons = StatusBarIconController.getIconHideList(
                         getContext(), newValue);
-                mView.setVisibility(icons.contains(mSlotBattery) ? View.GONE : View.VISIBLE);
+                mBatteryHidden = icons.contains(mSlotBattery);
+                mView.setVisibility(mBatteryHidden ? View.GONE : View.VISIBLE);
+                if (!mBatteryHidden) {
+                    mView.updateBatteryStyle();
+                }
             }
         }
     };
@@ -109,6 +111,8 @@ public class BatteryMeterViewController extends ViewController<BatteryMeterView>
     // Some places may need to show the battery conditionally, and not obey the tuner
     private boolean mIgnoreTunerUpdates;
     private boolean mIsSubscribedForTunerUpdates;
+
+    private boolean mBatteryHidden;
 
     @Inject
     public BatteryMeterViewController(
@@ -187,10 +191,15 @@ public class BatteryMeterViewController extends ViewController<BatteryMeterView>
 
     private void registerShowBatteryPercentObserver(int user) {
         mContentResolver.registerContentObserver(
-                Settings.System.getUriFor(SHOW_BATTERY_PERCENT),
-                false,
-                mSettingObserver,
-                user);
+            Settings.System.getUriFor(Settings.System.STATUS_BAR_SHOW_BATTERY_PERCENT),
+            false,
+            mSettingObserver,
+            user);
+        mContentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.STATUS_BAR_BATTERY_STYLE),
+            false,
+            mSettingObserver,
+            user);
     }
 
     private void registerGlobalBatteryUpdateObserver() {
@@ -213,6 +222,9 @@ public class BatteryMeterViewController extends ViewController<BatteryMeterView>
                     Settings.Global.BATTERY_ESTIMATES_LAST_UPDATE_TIME)) {
                 // update the text for sure if the estimate in the cache was updated
                 mView.updatePercentText();
+            }
+            if (TextUtils.equals(uri.getLastPathSegment(), Settings.System.STATUS_BAR_BATTERY_STYLE)) {
+                mView.updateBatteryStyle();
             }
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
@@ -66,7 +66,6 @@ public class KeyguardStatusBarView extends RelativeLayout {
 
     private final ArrayList<Rect> mEmptyTintRect = new ArrayList<>();
 
-    private boolean mShowPercentAvailable;
     private boolean mBatteryCharging;
 
     private TextView mCarrierLabel;
@@ -196,8 +195,6 @@ public class KeyguardStatusBarView extends RelativeLayout {
                 R.dimen.ongoing_appops_dot_min_padding);
         mCutoutSideNudge = getResources().getDimensionPixelSize(
                 R.dimen.display_cutout_margin_consumption);
-        mShowPercentAvailable = getContext().getResources().getBoolean(
-                com.android.internal.R.bool.config_battery_percentage_setting_available);
         mRoundedCornerPadding = res.getDimensionPixelSize(
                 R.dimen.rounded_corner_content_padding);
     }
@@ -234,7 +231,7 @@ public class KeyguardStatusBarView extends RelativeLayout {
                 mMultiUserAvatar.setVisibility(View.GONE);
             }
         }
-        mBatteryView.setForceShowPercent(mBatteryCharging && mShowPercentAvailable);
+        mBatteryView.setForceShowPercent(mBatteryCharging);
     }
 
     private void updateSystemIconsLayoutParams() {

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerService.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerService.java
@@ -75,4 +75,12 @@ public abstract class TunerService {
             return defaultValue;
         }
     }
+
+    public static int parseInteger(String value, int defaultValue) {
+        try {
+            return value != null ? Integer.parseInt(value) : defaultValue;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
 }

--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -26,6 +26,7 @@ import static android.media.AudioManager.STREAM_MUSIC;
 import static android.media.AudioManager.STREAM_SYSTEM;
 import static android.os.Process.FIRST_APPLICATION_UID;
 import static android.os.Process.INVALID_UID;
+import static android.provider.Settings.Secure.VOLUME_HUSH_CYCLE;
 import static android.provider.Settings.Secure.VOLUME_HUSH_MUTE;
 import static android.provider.Settings.Secure.VOLUME_HUSH_OFF;
 import static android.provider.Settings.Secure.VOLUME_HUSH_VIBRATE;
@@ -5375,6 +5376,25 @@ public class AudioService extends IAudioService.Stub
                 effect = VibrationEffect.get(VibrationEffect.EFFECT_HEAVY_CLICK);
                 ringerMode = AudioManager.RINGER_MODE_VIBRATE;
                 toastText = com.android.internal.R.string.volume_dialog_ringer_guidance_vibrate;
+                break;
+            case VOLUME_HUSH_CYCLE:
+                switch (mRingerMode) {
+                    case AudioManager.RINGER_MODE_NORMAL:
+                        effect = VibrationEffect.get(VibrationEffect.EFFECT_HEAVY_CLICK);
+                        ringerMode = AudioManager.RINGER_MODE_VIBRATE;
+                        toastText = com.android.internal.R.string.volume_dialog_ringer_guidance_vibrate;
+                        break;
+                    case AudioManager.RINGER_MODE_VIBRATE:
+                        effect = VibrationEffect.get(VibrationEffect.EFFECT_DOUBLE_CLICK);
+                        ringerMode = AudioManager.RINGER_MODE_SILENT;
+                        toastText = com.android.internal.R.string.volume_dialog_ringer_guidance_silent;
+                        break;
+                    case AudioManager.RINGER_MODE_SILENT:
+                        effect = VibrationEffect.get(VibrationEffect.EFFECT_HEAVY_CLICK);
+                        ringerMode = AudioManager.RINGER_MODE_NORMAL;
+                        toastText = com.android.internal.R.string.volume_dialog_ringer_guidance_normal;
+                        break;
+                }
                 break;
         }
         maybeVibrate(effect, reason);


### PR DESCRIPTION
- Don't check build fingerprint
it's needed this commit for few devices to prevent error message on boot.

- battery style tweakable
I didn't inplemented the toggle but I confirmed works on
`adb shell settings put system status_bar_battery_style *` and `adb shell settings put system status_bar_show_battery_percent *`. so you can implement toggle for this into Evolver.

- Cycle through ringer modes
This makes better UX on Pixels.

And also:
- I tried to find out commits of separated Wi-Fi tile and mobile data tile but I getting nothing yet

- Tried "Add Sound tile on QS" but it doesn't showing.

Reason: Bring back nice Android 11 silent mode toggle experience. (Android 12+ was sucks)

WIP: https://github.com/nattolecats/frameworks_base/commit/3fbd0f4d1990ee9da7f5801605173e50cbea7a38#diff-0db7de6f6621e333f0023a232a176e34cb7413a324c69b08d80f96e0aea94fc2