### PR TITLE
Youtube application when moving to PIP animation was very bad Problem: {     1. Open youtube video premium. Start any video.     2. Press back make the video smaller.     3. Then press home or back from navigation buttons.     4. Observe animation surface is very weird. }  Solution: {     1. Youtube itself has set very small pip args. That causes surface to first scale then animate.     2. So set the sourceHintRect to null. To show only color overlay and animate the task snapshot only.     3. Will make better user effect. }  Ported from SOSP

### DIFF
--- a/libs/WindowManager/Shell/src/com/android/wm/shell/pip/PipTaskOrganizer.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/pip/PipTaskOrganizer.java
@@ -617,8 +617,14 @@ public class PipTaskOrganizer implements ShellTaskOrganizer.TaskListener,
         mSyncTransactionQueue.runInSync(t -> {
             // Make sure to grab the latest source hint rect as it could have been
             // updated right after applying the windowing mode change.
-            final Rect sourceHintRect = PipBoundsAlgorithm.getValidSourceHintRect(
+            Rect sourceHintRect = PipBoundsAlgorithm.getValidSourceHintRect(
                     mPictureInPictureParams, destinationBounds);
+                 if (sourceHintRect != null && currentBounds != null
+                    && sourceHintRect.width() < currentBounds.width() / 2
+                    && sourceHintRect.height() < currentBounds.height() / 3) {
+                sourceHintRect = null;
+            }
+        
             final PipAnimationController.PipTransitionAnimator<?> animator =
                     animateResizePip(mPipBoundsState.getBounds(), destinationBounds, sourceHintRect,
                             direction, animationDurationMs, 0 /* startingAngle */);


### PR DESCRIPTION
Youtube application when moving to PIP animation was very bad
Problem: {
    1. Open youtube video premium. Start any video.
    2. Press back make the video smaller.
    3. Then press home or back from navigation buttons.
    4. Observe animation surface is very weird.
}

Solution: {
    1. Youtube itself has set very small pip args. That causes surface to first scale then animate.
    2. So set the sourceHintRect to null. To show only color overlay and animate the task snapshot only.
    3. Will make better user effect.
}

Ported from SOSP