### PR TITLE
PPU: Spoof to recent Pixel on iD apps

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -89,7 +89,8 @@ public class PixelPropsUtils {
             "com.microsoft.android.smsorganizer",
             "com.nhs.online.nhsonline",
             "com.nothing.smartcenter",
-            "in.startv.hotstar"
+            "in.startv.hotstar",
+            "jp.id_credit_sp2.android"
     };
 
     private static final String[] customGoogleCameraPackages = {


### PR DESCRIPTION
* This fixes some JP devices get refusing launch iD apps.

iD app allows only phones thyself sold, otherwise not allowed to use.
This commit makes allows whitelist on iD apps.
(iD is Japan popular payment apps from NTT DOCOMO)