### PR TITLE
PPU: Stop spoofing com.google.android.googlequicksearchbox

### DIFF
--- a/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/evolution/PixelPropsUtils.java
@@ -118,6 +118,7 @@ public class PixelPropsUtils {
             "com.google.android.as",
             "com.google.android.dialer",
             "com.google.android.euicc",
+            "com.google.android.googlequicksearchbox",
             "com.google.android.setupwizard",
             "com.google.android.youtube",
             "com.google.ar.core",


### PR DESCRIPTION
- Makes AR vision with camera crash due to app expecting Pixel camera but it isn't