### PR TITLE
Normalize wakelock blocker

### DIFF
--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -1748,15 +1748,17 @@ public final class PowerManagerService extends SystemService
                 tag = tag.substring(0,9);
             }
 
+            String tagNormalized = tag.replaceAll("#\\d*$", "");
+
             boolean blockWakelock = false;
-            if (!mSeenWakeLocks.contains(tag)) {
+            if (!mSeenWakeLocks.contains(tagNormalized)) {
                 if ((flags & PowerManager.WAKE_LOCK_LEVEL_MASK) == PowerManager.PARTIAL_WAKE_LOCK) {
-                    mSeenWakeLocks.add(tag);
+                    mSeenWakeLocks.add(tagNormalized);
                 }
             }
 
             if (mWakeLockBlockingEnabled == 1) {
-                if (mBlockedWakeLocks.contains(tag)) {
+                if (mBlockedWakeLocks.contains(tagNormalized)) {
                     blockWakelock = true;
                 }
             }


### PR DESCRIPTION
Currently to block an app's service entirely you must periodically check Wakelock blocker to see if new entries for the service were added since last save.
I've found hundreds of wakelocks for the same service which are only differentiated by the hash at the end.

I believe it would be a good idea to normalize seen wakelocks just for the Wakelock blocker function.
This should also help remedy https://github.com/Evolution-X/packages_apps_Evolver/issues/607

<img src="https://github.com/cmeka/frameworks_base/assets/6840353/6303ae04-3b31-454f-8dc8-fee4885eae8a" width=50% height=50%>