### PR TITLE
base: core: Unregister broadcast receiver only when registered

### DIFF
--- a/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
+++ b/core/java/com/android/internal/policy/GestureNavigationSettingsObserver.java
@@ -42,6 +42,7 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
     private Runnable mOnChangeRunnable;
     private Handler mMainHandler;
     private IntentFilter mIntentFilter;
+    private boolean mRegistered = false;
 
     public GestureNavigationSettingsObserver(Handler handler, Context context,
             Runnable onChangeRunnable) {
@@ -141,6 +142,7 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
      */
     public void register() {
         mContext.registerReceiver(mBroadcastReceiver, mIntentFilter);
+        mRegistered = true;
         ContentResolver r = mContext.getContentResolver();
         r.registerContentObserver(
                 Settings.Secure.getUriFor(Settings.Secure.BACK_GESTURE_INSET_SCALE_LEFT),
@@ -202,7 +204,9 @@ public class GestureNavigationSettingsObserver extends ContentObserver {
     }
 
     public void unregister() {
-        mContext.unregisterReceiver(mBroadcastReceiver);
+        if (mRegistered) {
+            mContext.unregisterReceiver(mBroadcastReceiver);
+        }
         mContext.getContentResolver().unregisterContentObserver(this);
         DeviceConfig.removeOnPropertiesChangedListener(mOnPropertiesChangedListener);
     }


### PR DESCRIPTION
- Prevent launcher crashing every time when gesture setting is enabled and launcher is refreshed
- This issue only exists when Taskbar is enabled

Error: <https://paste.evolution-x.org/Vd4BeI>